### PR TITLE
--nominifyjs and --indent options allow for combination-only processing.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,11 +9,11 @@ CSS bundles are created from assets which are
 * bundled
 * preprocessed via [enhance-css](https://github.com/GoalSmashers/enhance-css) (inline images, asset hosts, etc)
 * packaged (and optionally precompressed)
-    
+
 And JavaScripts ones are
 
 * bundled
-* minified using wonderful [UglifyJS](https://github.com/mishoo/UglifyJS)
+* minified using the wonderful [UglifyJS](https://github.com/mishoo/UglifyJS)
 * packaged (and optionally precompressed)
 
 ## Usage ##
@@ -31,7 +31,7 @@ OK. Clone this repo.
 Then open examples directory and run:
 
     assetspkg -c assets.yml -g
-    
+
 Now check _examples/public/javascripts/bundled_ and _examples/public/stylesheets/bundled_ for bundled code.
 That's it!
 
@@ -54,7 +54,7 @@ First of all it assumes you have Rails-like directory structure for your assets,
         - _some stylesheets_
 
 Then it also needs a configuration file (here we name it assets.yml) with a definition of JS/CSS bundles, e.g:
-    
+
     # stylesheets
     stylesheets:
       application: 'reset,grid,base,application'
@@ -69,26 +69,35 @@ We recommend placing it somewhere else than in your _public_ folder (could be _c
 Now you can bundle all these packages with a single command:
 
     assetspkg -c assets.yml
-    
+
 All the packages go into _public/javascripts/bundled_ and _public/stylesheets/bundled_.
 You'll probably want to put that command somewhere into your build/deploy script.
 
 ### How to configure it? ###
 
     assetspkg -h
-    
+
 Options include:
 
 * -g - create gzipped bundles (useful if your server supports serving precompressed files, like [nginx](http://wiki.nginx.org/NginxHttpGzipStaticModule))
 * -n - create alternate stylesheets bundles without inlined images (Explorer 6/7, I'm looking at you!)
 * -a - use asset hosts for image URLs, e.g _-a [assets0,assets1].yourdomain.com_
 * -o - narrow the set of bundles being build, e.g. _-o application.js_, _-o *.css_, or _-o public.css,application.css_
+* --nm - do not minify JS, only combine (use the `beautify` option of UglifyJS)
+* -i - when using --nm, specify the indentation level in spaces
 
 ### The feature I want is not there! ###
 
 Open an issue. Or better: fork the project, add the feature (don't forget about tests!) and send a pull request.
 
 ### How to test assets-packager? ###
+
+First, install dependencies
+
+    npm install
+    npm install -g less@latest
+
+Then, run the specs
 
     make test
 

--- a/bin/assetspkg
+++ b/bin/assetspkg
@@ -9,7 +9,7 @@ var fs = require('fs'),
   cleanCSS = require('clean-css'),
   EnhanceCSS = require('enhance-css'),
   AssetsExpander = require('assets-expander');
-  
+
 // Taken from MooTools 1.3
 var escapeRegExp = function(s) {
   return s.replace(/([-.*+?^${}()|[\]\/\\])/g, '\\$1');
@@ -19,6 +19,8 @@ var escapeRegExp = function(s) {
 var options = {
   root: 'public',
   config: 'config/assets.yml',
+  noMinifyJS: false,
+  indentLevel: 0,
   gzip: false,
   noEmbedVersion: false,
   only: undefined,
@@ -30,6 +32,8 @@ var argv = require('optimist').argv;
 options.root = path.join(process.cwd(), argv.r || argv.root || options.root);
 options.config = path.join(process.cwd(), argv.c || argv.config || options.config);
 options.gzip = argv.g || argv.gzip || options.gzip;
+options.noMinifyJS = argv.nm || argv.nominifyjs || options.noMinifyJS;
+options.indentLevel = argv.i || argv.indent || options.indentLevel;
 options.noEmbedVersion = argv.n || argv.noembedversion || options.noEmbedVersion;
 options.only = argv.o || argv.only || options.only;
 
@@ -54,14 +58,15 @@ options.assetHosts = argv.a || argv.assethosts || options.assetHosts;
 if (argv.h || argv.help) {
   sys.puts("usage: assetspkg [options]\n");
   sys.puts("options:");
-  sys.puts("  -c, --config\t\tPath to file with assets definitions (defaults to ./config/assets.yml)");
-  sys.puts("  -r, --root\t\tRoot directory, relative to all will be made (defaults to ./public)");
-  sys.puts("  -g, --gzip\t\tGzip packaged files (defaults to false).");
-  sys.puts("  -n, --noembedversion\tCreate a version of packaged CSS without embedded images (defaults to false).");
-  sys.puts("  -a, --assethosts\tAssets host to use in CSS bundles (defaults to none).");
-  sys.puts("  -o, --only\t\tPackage only given assets group (or groups if separated by comma).");
-  sys.puts("  -h, --help\t\tYou are staring at it!");
-  sys.puts("  -v, --version\t\tAssets Packager version.");
+  sys.puts("  -c,  --config\t\tPath to file with assets definitions (defaults to ./config/assets.yml)");
+  sys.puts("  -r,  --root\t\tRoot directory, relative to all will be made (defaults to ./public)");
+  sys.puts("  -g,  --gzip\t\tGzip packaged files (defaults to false).");
+  sys.puts("  -nm, --nominifyjs\t\tOnly combine JS files, do not minify them (defaults to false).");
+  sys.puts("  -n,  --noembedversion\tCreate a version of packaged CSS without embedded images (defaults to false).");
+  sys.puts("  -a,  --assethosts\tAssets host to use in CSS bundles (defaults to none).");
+  sys.puts("  -o,  --only\t\tPackage only given assets group (or groups if separated by comma).");
+  sys.puts("  -h,  --help\t\tYou are staring at it!");
+  sys.puts("  -v,  --version\t\tAssets Packager version.");
   process.exit(0);
 }
 
@@ -101,7 +106,7 @@ Seq.ap(expander.allTypes()).
   seqEach(function(type) {
     if (type == 'stylesheets' && options.only && !options.only.hasCSS) return this(null);
     if (type == 'javascripts' && options.only && !options.only.hasJS) return this(null);
-    
+
     // Then process all files
     var self = this;
     sys.puts("Processing type '" + type + "'...");
@@ -109,7 +114,7 @@ Seq.ap(expander.allTypes()).
     Seq.ap(expander.groupsFor(type)).
       parEach(4, function(groupName) {
         if (options.only && !options.only.has(groupName + '.' + extensions[type])) return this(null);
-        
+
         processGroup(type, groupName, this);
       }).
       seq('type', self, null)
@@ -130,7 +135,7 @@ var joinFiles = function(list) {
 var compileLessToCss = function(type, callback) {
   var filesList = expander.processList(type + '/**/*', { type: 'less', root: options.root });
   sys.puts("Compiling " + filesList.length + " Less file(s) to CSS...");
-  
+
   Seq.ap(filesList).
     parEach(function(pathToLessFile) {
       sys.puts("  Compiling '" + path.basename(pathToLessFile) + "'...");
@@ -146,7 +151,7 @@ var processGroup = function(type, group, callback) {
   var filesList = expander.processGroup(type, group, { type: extensions[type] }),
     groupPath = path.join(options.root, type, 'bundled', group) + '.' + extensions[type],
     groupDir = path.dirname(groupPath);
-  
+
   if (type == 'stylesheets') {
     Seq().
       seq(function() {
@@ -162,12 +167,12 @@ var processGroup = function(type, group, callback) {
       }).
       par(function(data) { // compressed plain file
         if (!options.gzip) return this(null);
-        
+
         fs.writeFile(groupPath + '.gz', data.embedded.compressed, 'utf-8', this);
       }).
       par(function(data) { // not-embedded version
         if (!options.noEmbedVersion) return this(null);
-        
+
         fs.writeFile(groupPath.replace('.' + extensions[type], '-noembed.' + extensions[type]), data.notEmbedded.plain, 'utf-8', this);
       }).
       par(function(data) { // not-embedded, gzipped version
@@ -190,22 +195,22 @@ var processGroup = function(type, group, callback) {
         var isCufon = /Cufon\.registerFont/.test(content);
         var ast = uglify.parser.parse(content);
         var data = '';
-        
-        if (!isCufon) {
-          // We skip mangling for Cufon as it doesn't like it.
+
+        if (isCufon || options.noMinifyJS) {
+          // Maybe no minification was required. We also skip mangling for Cufon as it doesn't like it.
+          data = uglify.uglify.gen_code(ast, { beautify: true, indent_level: options.indentLevel });
+        } else {
           ast = uglify.uglify.ast_mangle(ast);
           ast = uglify.uglify.ast_squeeze(ast);
           data = uglify.uglify.gen_code(ast);
           data = uglify.uglify.split_lines(data, 80);
-        } else {
-          data = uglify.uglify.gen_code(ast, { beautify: true, indent_level: 0 });
         }
-        
+
         fs.writeFile(groupPath, data, 'utf-8', this);
       }).
       seq(function() {
         if (!options.gzip) return this(null);
-        
+
         exec('gzip -c6 ' + groupPath + ' > ' + groupPath + '.gz', this);
       }).
       seq(function() {

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -400,7 +400,7 @@ exports.javascriptOptimizing = vows.describe('javascript optimizing').addBatch({
       },
       'data': function(error, data) {
         if (error) throw error;
-        
+
         assert.equal(["function factorial(a){return a==0?1:a*factorial(a-1)}for(var i=0,j=factorial(10).", "toString(),k=j.length;i<k;i++)console.log(j[i])"].join('\n'),
           data);
       }
@@ -411,9 +411,26 @@ exports.javascriptOptimizing = vows.describe('javascript optimizing').addBatch({
       },
       'data': function(error, data) {
         if (error) throw error;
-        
+
         assert.equal("Cufon.registerFont(function(f) {\nvar b = _cufon_bridge_ = {\np: [ {\nd: \"88,-231v18,-2,31,19,8,26v-86,25,-72,188,-18,233v7,4,17,4,17,13v-1,14,-12,18,-26,10v-19,-10,-48,-49,-56,-77\"\n} ]\n};\n});",
           data)
+      }
+    },
+    teardown: function() {
+      cleanBundles('test3');
+    }
+  }
+}).addBatch({
+  'no JS minification': {
+    topic: withOptions('-r data/test3/public --nm -i 2 -c data/test3/assets.yml'),
+    'for optimizations.js': {
+      topic: function() {
+        fs.readFile(fullPath('test/data/test3/public/javascripts/bundled/optimizations.js'), 'utf-8', this.callback);
+      },
+      'data': function(error, data) {
+        if (error) throw error;
+
+        assert.equal(data, "function factorial(n) {\n  if (n == 0) {\n    return 1;\n  }\n  return n * factorial(n - 1);\n}\n\nfor (var i = 0, j = factorial(10).toString(), k = j.length; i < k; i++) {\n  console.log(j[i]);\n}");
       }
     },
     teardown: function() {


### PR DESCRIPTION
Hi,

I needed a way to combine but no minify JS files, so as to release dual versions of a lib which sources are splitted in several files: a combined+minified version for production, and a combined-only version for development.

I thus added these options in assets-packager, relying on UglifyJS' options.
